### PR TITLE
Added Config Option To Ignore SSL Errors

### DIFF
--- a/traefiktounifi/app.py
+++ b/traefiktounifi/app.py
@@ -26,9 +26,6 @@ def sync():
     if traefik_api_url is None:
         raise ValueError("TRAEFIK_API_URL environment variable is not set.")
 
-    if ignore_ssl_warnings is None:
-        ignore_ssl_warnings = False
-
     print(f"The value of UNIFI_URL is: {unifi_url}")
     print(f"The value of TRAEFIK_API_URL is: {traefik_api_url}")
 

--- a/traefiktounifi/app.py
+++ b/traefiktounifi/app.py
@@ -9,7 +9,7 @@ def sync():
     unifi_url = os.environ.get("UNIFI_URL")
     unifi_username = os.environ.get("UNIFI_USERNAME")
     unifi_password = os.environ.get("UNIFI_PASSWORD")
-    ignore_ssl_warnings = os.environ.get("INGNORE_SSL_WARNINGS")
+    ignore_ssl_warnings = os.environ.get("IGNORE_SSL_WARNINGS")
 
     if unifi_url is None:
         raise ValueError("UNIFI_URL environment variable is not set.")

--- a/traefiktounifi/app.py
+++ b/traefiktounifi/app.py
@@ -9,6 +9,7 @@ def sync():
     unifi_url = os.environ.get("UNIFI_URL")
     unifi_username = os.environ.get("UNIFI_USERNAME")
     unifi_password = os.environ.get("UNIFI_PASSWORD")
+    ignore_ssl_warnings = os.environ.get("INGNORE_SSL_WARNINGS")
 
     if unifi_url is None:
         raise ValueError("UNIFI_URL environment variable is not set.")
@@ -24,6 +25,9 @@ def sync():
 
     if traefik_api_url is None:
         raise ValueError("TRAEFIK_API_URL environment variable is not set.")
+
+    if ignore_ssl_warnings is None:
+        ignore_ssl_warnings = False
 
     print(f"The value of UNIFI_URL is: {unifi_url}")
     print(f"The value of TRAEFIK_API_URL is: {traefik_api_url}")
@@ -56,6 +60,10 @@ def sync():
         exit(0)
 
     unifi_session = requests.Session()
+
+    if ignore_ssl_warnings:
+        requests.packages.urllib3.disable_warnings()
+        unifi_session.verify = False
 
     unifi_login_response = unifi_session.post(
         f"{unifi_url}api/auth/login",


### PR DESCRIPTION
I have added an option to ignore SSL errors - while this is not ideal, if connecting to a UDM Pro from a Docker container, the MDNS record of unifi.local (Certificate Root) cannot be resolved and therefore presents a bunch of SSL warnings.

This fix allows you to go ahead with it if you _really_ want to although, I'd heavily caveat it by saying, this will transmit credentials in a plain text scope so Unifi Controller API credentials will have to be narrowly scoped and is not recommended.