### PR TITLE
add docker-compose.yml and updated usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,62 @@ This project aims to integrate Traefik with UniFi, allowing for routes populated
 
 ## Usage
 
-Install dependencies with `poetry install`
+Install dependencies using `poetry install`.
 
-Either via the Docker container or run `poetry run python app.py`. Be sure to have the environment variables listed above available.
+You can run the application either via the Docker container or directly with:
+
+```bash
+poetry run python app.py
+```
+
+Make sure all required environment variables (listed above) are set.
+
+### Example `.env` file
+You should create a `.env` file containing your secrets. This file **should not be committed** to git.
+
+```
+TRAEFIK_API_URL=http://traefik:8080/api/
+TRAEFIK_IP=192.168.1.10
+UNIFI_URL=https://unifi:8443/
+UNIFI_USERNAME=admin
+UNIFI_PASSWORD=supersecret
+```
+
+### Running with Docker (without docker-compose)
+
+1. Build the Docker image:
+
+```bash
+docker build -t traefik-to-unifi .
+```
+
+2. Run the container using a `.env` file:
+
+```bash
+docker run --env-file .env traefik-to-unifi
+```
+
+Or by passing environment variables directly:
+
+```bash
+docker run -e TRAEFIK_API_URL=http://traefik:8080/api/ \
+           -e TRAEFIK_IP=192.168.1.10 \
+           -e UNIFI_URL=https://unifi:8443/ \
+           -e UNIFI_USERNAME=admin \
+           -e UNIFI_PASSWORD=supersecret \
+           traefik-to-unifi
+```
+
+### Running with Docker Compose
+
+Build the image and start the service:
+
+```bash
+docker compose build
+docker compose up
+```
+
+Make sure your `.env` file is next to `docker-compose.yml` so the secrets are loaded automatically.
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  traefik-to-unifi:
+    build: .
+    container_name: traefik-to-unifi
+    restart: unless-stopped
+    env_file:
+      - .env


### PR DESCRIPTION
I like to run my containers with docker compose - so I added a `docker-compose.yml` file that useses the existing `Dockerfile` to build the image and loads the environment variables from the file `.env` - which is already in `.gitignore`.

And I've updated the readme.md with more instructions on how to run the script (with docker and docker-compose)