### PR TITLE
added logging, CNAME support, ignore TLS validation and faster/partial sync

### DIFF
--- a/traefiktounifi/__init__.py
+++ b/traefiktounifi/__init__.py
@@ -1,0 +1,32 @@
+import os
+import logging
+
+# ANSI color codes
+RESET = "\033[0m"
+GRAY = "\033[90m"
+YELLOW = "\033[33m"
+RED = "\033[31m"
+
+class ColorFormatter(logging.Formatter):
+    COLORS = {
+        logging.DEBUG: GRAY,
+        logging.INFO: "",
+        logging.WARNING: YELLOW,
+        logging.ERROR: RED,
+        logging.CRITICAL: RED,
+    }
+
+    def format(self, record):
+        color = self.COLORS.get(record.levelno, "")
+        message = super().format(record)
+        return f"{color}{message}{RESET}"
+
+# Create logger
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO").upper())
+
+handler = logging.StreamHandler()
+formatter = ColorFormatter("%(asctime)s [%(levelname)s] %(message)s")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+

--- a/traefiktounifi/app.py
+++ b/traefiktounifi/app.py
@@ -1,62 +1,129 @@
 import os
 import requests
 import re
+import json
+import logging
 
+# global variables for optimized syncs
+traefik_domains_json_last_run = "[]"
+number_of_syncs_without_change = 0
+is_first_run = True
 
 def sync():
+    """
+    Synchronizes Traefik hostnames with Unifi static DNS entries.
+    - Fetches routers from Traefik API
+    - Extracts hostnames from router rules
+    - Compares them with existing Unifi static DNS entries
+    - Adds missing hosts or updates outdated ones
+    """
+
+    global traefik_domains_json_last_run
+    global number_of_syncs_without_change
+    global is_first_run
+
+    logging.info("Starting synchronization...")
+
+    # Load environment variables
     traefik_ip = os.environ.get("TRAEFIK_IP")
     traefik_api_url = os.environ.get("TRAEFIK_API_URL")
     unifi_url = os.environ.get("UNIFI_URL")
     unifi_username = os.environ.get("UNIFI_USERNAME")
     unifi_password = os.environ.get("UNIFI_PASSWORD")
+    ignore_ssl_warnings = os.environ.get("IGNORE_SSL_WARNINGS")
+    dns_record_type = os.environ.get("DNS_RECORD_TYPE", "A")
 
-    if unifi_url is None:
-        raise ValueError("UNIFI_URL environment variable is not set.")
+    # Validate required environment variables
+    for key, value in {
+        "UNIFI_URL": unifi_url,
+        "UNIFI_USERNAME": unifi_username,
+        "UNIFI_PASSWORD": unifi_password,
+        "TRAEFIK_IP": traefik_ip,
+        "TRAEFIK_API_URL": traefik_api_url,
+    }.items():
+        if value is None:
+            raise ValueError(f"Required environment variable {key} is not set.")
 
-    if unifi_username is None:
-        raise ValueError("UNIFI_USERNAME environment variable is not set.")
+    # Validate optional environment variables    
+    if dns_record_type not in ("A", "CNAME"):
+        raise ValueError(f"Invalid DNS_RECORD_TYPE: {dns_record_type}. Allowed values are 'A' or 'CNAME'.")
 
-    if unifi_password is None:
-        raise ValueError("UNIFI_PASSWORD environment variable is not set.")
+    if is_first_run:
+        logging.debug(f"UNIFI_URL={unifi_url}")
+        logging.debug(f"TRAEFIK_API_URL={traefik_api_url}")
 
-    if traefik_ip is None:
-        raise ValueError("TRAEFIK_IP environment variable is not set.")
+        if ignore_ssl_warnings:
+            # we show our own warning on startup, no warning on each request requried
+            requests.packages.urllib3.disable_warnings()
+            logging.warning(
+                f"IGNORE_SSL_WARNINGS={ignore_ssl_warnings} - "
+                "Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings")
 
-    if traefik_api_url is None:
-        raise ValueError("TRAEFIK_API_URL environment variable is not set.")
-
-    print(f"The value of UNIFI_URL is: {unifi_url}")
-    print(f"The value of TRAEFIK_API_URL is: {traefik_api_url}")
-
-    traefik_routers_response = requests.get(f"{traefik_api_url}http/routers")
+    logging.debug("Extracting hostnames from Traefik...")
+    # Request routers from Traefik API
+    traefik_routers_response = requests.get(f"{traefik_api_url}http/routers", verify=not ignore_ssl_warnings)
 
     if traefik_routers_response.status_code != 200:
         raise ValueError(
-            f"Failed to make request to Traefik API. Status code: {traefik_routers_response.status_code}"
+            f"Failed to query Traefik API. Status code: {traefik_routers_response.status_code}"
         )
 
     traefik_domains = []
 
     for router in traefik_routers_response.json():
         if "rule" in router and "Host(" in router["rule"]:
-            print(f"Router: {router['name']} with rule: {router['rule']}")
-
+            logging.debug(f"Router: {router['name']} with rule: {router['rule']}")
             match = re.search(r"Host\(`([^`]+)`\)", router["rule"])
+
             if not match:
-                print("No DNS name found in the rule.")
+                logging.debug(f"No DNS name found in the rule {router['rule']}.")
                 continue
 
             dns_name = match.group(1)
-            print(f"Extracted DNS name: {dns_name}")
+            logging.debug(f"Extracted hostname from Traefik: {dns_name}")
 
             traefik_domains.append(dns_name)
 
     if not traefik_domains:
-        print("No DNS names found in Traefik routers.")
-        exit(0)
+        logging.warning("No hostnames found in Traefik routers.")
+        return
 
+    # Detect changes compared to previous run
+    traefik_domains_json = json.dumps(traefik_domains, indent=4)
+    traefik_domains_json_changed = traefik_domains_json != traefik_domains_json_last_run;
+
+    if traefik_domains_json_changed:
+        number_of_syncs_without_change = 0
+        if is_first_run:
+            logging.debug(f"Extracted {len(traefik_domains)} hostnames in Traefik routers in first run.")
+        else:
+            logging.debug(f"Extracted {len(traefik_domains)} hostnames in Traefik routers and Detected changes since last run.")
+    else:
+        number_of_syncs_without_change += 1
+        logging.info(
+            f"No changes since last sync ({number_of_syncs_without_change} time(s) since last full sync)."
+        )
+
+    is_first_run = False
+    traefik_domains_json_last_run = traefik_domains_json
+
+    # Do not sync with unifi if there are no changes in the Traefik hostnames, but for saftey do it every 5th run so that manually modified dns records get fixed too.
+    if not traefik_domains_json_changed:
+
+        if number_of_syncs_without_change < 5:
+            logging.debug("Skipping Unifi update due to no changes.")
+            return
+        
+        # reset counter and do full sync
+        logging.debug("Performing full sync with Unifi despite no changes in Traefik hostnames.")
+        number_of_syncs_without_change = 0
+
+    # Login to Unifi
     unifi_session = requests.Session()
+    if ignore_ssl_warnings:
+        unifi_session.verify = False
 
+    logging.debug(f"Logging in to Unifi {unifi_url} ...")
     unifi_login_response = unifi_session.post(
         f"{unifi_url}api/auth/login",
         json={"username": unifi_username, "password": unifi_password},
@@ -67,10 +134,13 @@ def sync():
             f"Failed to login to Unifi API. Status code: {unifi_login_response.status_code}"
         )
 
+    logging.debug("Login successful, updating CSRF token.")
     unifi_session.headers.update(
         {"X-Csrf-Token": unifi_login_response.headers["X-Csrf-Token"]}
     )
 
+    # Fetch existing static DNS entries from Unifi
+    logging.debug("Fetching existing static DNS entries from Unifi...")
     get_static_dns_entries_response = unifi_session.get(
         f"{unifi_url}proxy/network/v2/api/site/default/static-dns"
     )
@@ -88,57 +158,71 @@ def sync():
     entries_to_update = []
     hosts_to_add = []
 
+    # Compare Traefik hostnames with Unifi static DNS entries
     for dns_name in traefik_domains:
-        print(f"Checking DNS name {dns_name} in Unifi static DNS entries.")
-
         already_exists = False
         for entry in unifi_static_dns_entries:
             if entry[0] == dns_name:
                 already_exists = True
                 if entry[1] != traefik_ip:
-                    print(
-                        f"DNS name {dns_name} already exists but with different IP address {entry[1]}. Updating it to {traefik_ip}."
+                    logging.info(
+                        f"DNS name {dns_name} already exists but with different value {entry[1]}. Schedule update to {traefik_ip}."
                     )
                     entries_to_update.append((entry[0], entry[2]))
                 break
 
         if not already_exists:
-            print(f"Adding DNS name {dns_name} to Unifi static DNS entries.")
+            logging.info(f"Schedule adding DNS name {dns_name} to Unifi static DNS entries.")
             hosts_to_add.append(dns_name)
 
-    for entry in entries_to_update:
+    logging.info(
+        f"DNS entries to update: {len(entries_to_update)}, "
+        f"new DNS entries to add: {len(hosts_to_add)}"
+    )
+
+    if not entries_to_update and not hosts_to_add:
+        logging.debug("No changes required for Unifi static DNS entries.")
+    else:
+        logging.info(f"Updating DNS entries using DNS record type: {dns_record_type}")
+
+
+    # Update existing entries
+    for key, entry_id in entries_to_update:
         update_static_dns_entry_response = unifi_session.put(
-            f"{unifi_url}proxy/network/v2/api/site/default/static-dns/{entry[1]}",
+            f"{unifi_url}proxy/network/v2/api/site/default/static-dns/{entry_id}",
             json={
                 "enabled": True,
-                "key": entry[0],
-                "record_type": "A",
+                "key": key,
+                "record_type": dns_record_type,
                 "value": traefik_ip,
-                "_id": entry[1],
+                "_id": entry_id,
             },
         )
 
         if update_static_dns_entry_response.status_code == 200:
-            print(f"Updated static DNS entry {entry[0]} in Unifi API.")
+            logging.info(f"Successfully updated DNS entry {key} in Unifi API.")
         else:
-            print(
-                f"Failed to update static DNS entry in Unifi API. Status code: {update_static_dns_entry_response.status_code}"
+            logging.error(
+                f"Failed to update static DNS entry {key} in Unifi API. Status code: {update_static_dns_entry_response.status_code}"
             )
 
+    # Add new entries
     for host in hosts_to_add:
         add_static_dns_entry_response = unifi_session.post(
             f"{unifi_url}proxy/network/v2/api/site/default/static-dns",
             json={
                 "enabled": True,
                 "key": host,
-                "record_type": "A",
+                "record_type": dns_record_type,
                 "value": traefik_ip,
             },
         )
 
         if add_static_dns_entry_response.status_code == 200:
-            print(f"Added static DNS entry {host} in Unifi API.")
+            logging.info(f"Successfully added DNS entry {host} in Unifi API.")
         else:
-            print(
-                f"Failed to add static DNS entry in Unifi API. Status code: {add_static_dns_entry_response.status_code}"
+            logging.error(
+                f"Failed to add static DNS entry {host} in Unifi API. Status code: {add_static_dns_entry_response.status_code}"
             )
+
+    logging.debug("Synchronization completed.")

--- a/traefiktounifi/runner.py
+++ b/traefiktounifi/runner.py
@@ -3,7 +3,7 @@ import schedule
 import time
 
 app.sync()
-schedule.every(5).minutes.do(app.sync)
+schedule.every(1).minutes.do(app.sync)
 
 # Keep the script running indefinitely
 while True:


### PR DESCRIPTION
I had a issure with logging in docker: `print(...)` was written to STDOUT but python seems to cache the output. When there was an exception I could see all the details but as long as everything was fine I was not able to see anything in the log with `docker compose logs`.

Possible Solution would be to add this in the `Dockerfile`:
```
ENV PYTHONUNBUFFERED=1
```

But I switched from print to logging - including timestamp, loglevel (with coloring) and support for docker logs ;)
The minimum log-level can be defined with environment variable `LOG_LEVEL` (DEBUG, INFO, WARNING, ERROR)

Starting with version ~9.3 Unifi network supports DNS record type CNAME - so I added an option to create CNAME-records to another host instead of A-records to a fixed IP ip address.

I've seen an Option to ignore/skip TLS validation in two other forks and combined there implementation with an additional (one-time) warning-log.

Waiting up to 5 minutes for new DNS-Entries was to boring - so I've changed the sync-flow a little bit:
By comparing the extracted dns-records from traefik from the last sync-cycle with the current we can simply check if there was relevant a change in Traefik router configuration. 
Without changes we can skip login & update of the Unifi DNS entries because there is only a small chance that someone has modified the existig entries manually ;)
So by skipping the Unifiy communicaton I had no bad feelings to change the schedule from every 5 minutes to every minute.
Bonus: every 5th cycle without change the Unifi update will be done anyway...